### PR TITLE
refactor: use `io.Reader` as args of `ParseMarkdownWithMetadata()`

### DIFF
--- a/internal/markdown/parse.go
+++ b/internal/markdown/parse.go
@@ -1,7 +1,7 @@
 package markdown
 
 import (
-	"bytes"
+	"io"
 	"strings"
 
 	"github.com/adrg/frontmatter"
@@ -26,10 +26,10 @@ type (
 // provided type T. The rest of the content is returned as a string.
 //
 // If the front matter is not present, FrontMatter will be empty.
-func ParseMarkdownWithMetadata[T any](content []byte) (ParsedMarkdown[T], error) {
+func ParseMarkdownWithMetadata[T any](input io.Reader) (ParsedMarkdown[T], error) {
 	fm := new(T)
 	// Parse the front matter and require it to be present
-	rest, err := frontmatter.Parse(bytes.NewReader(content), fm)
+	rest, err := frontmatter.Parse(input, fm)
 	if err != nil {
 		return ParsedMarkdown[T]{}, err
 	}

--- a/mdfm.go
+++ b/mdfm.go
@@ -157,12 +157,13 @@ func GlobFrontMatter[T any](
 // It extracts frontmatter metadata and returns the processed document.
 // This function is used internally by GlobFrontMatter for concurrent processing.
 func processMarkdownFile[T any](path string) (*MarkdownDocument[T], error) {
-	body, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
-	md, err := markdown.ParseMarkdownWithMetadata[T](body)
+	md, err := markdown.ParseMarkdownWithMetadata[T](f)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance
  - Markdown parsing now streams input, reducing memory usage and improving responsiveness with large files.
- Refactor
  - Updated the parsing pipeline to use streaming reads with proper resource management. Outputs and configuration remain unchanged.
- Tests
  - Test suite adjusted to validate the new streaming input path; coverage and expected results remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->