### PR TITLE
ci: use existing draft from GpReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,6 +59,7 @@ changelog:
       - "^tagpr:"
 
 release:
+  use_existing_draft: true
   github:
     owner: sushichan044
     name: mdfm

--- a/.tagpr
+++ b/.tagpr
@@ -49,5 +49,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = version/version.go
-	# GitHub Releases will be created by GoReleaser
-	release = false
+	release = draft


### PR DESCRIPTION
ref: https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html