### PR TITLE
feat: add pretty option and remove indent by default

### DIFF
--- a/cmd/mdfm/mdfm.go
+++ b/cmd/mdfm/mdfm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -25,6 +26,8 @@ type (
 		Version kong.VersionFlag `short:"v"`
 
 		JQ string `name:"jq" help:"jq filter to apply to each JSON object."`
+
+		Pretty bool `name:"pretty" help:"Pretty-print JSON output."`
 	}
 )
 
@@ -43,7 +46,11 @@ func (cmd *CLI) Run() error {
 		}
 	}()
 
-	printer, printerErr := NewAppropriatePrinter(wtr, cmd.JQ)
+	enc := json.NewEncoder(wtr)
+	if cmd.Pretty {
+		enc.SetIndent("", "  ")
+	}
+	printer, printerErr := NewAppropriatePrinter(enc, cmd.JQ)
 	if printerErr != nil {
 		return fmt.Errorf("failed to configure output printer: %w", printerErr)
 	}

--- a/cmd/mdfm/payload.go
+++ b/cmd/mdfm/payload.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"io"
 
 	"github.com/itchyny/gojq"
 )
@@ -34,10 +33,7 @@ func (p jsonPayload) AsMap() map[string]any {
 	return result
 }
 
-func NewAppropriatePrinter(output io.Writer, jqFilter string) (payloadPrinter, error) {
-	enc := json.NewEncoder(output)
-	enc.SetIndent("", "  ")
-
+func NewAppropriatePrinter(enc *json.Encoder, jqFilter string) (payloadPrinter, error) {
 	var jqCode *gojq.Code
 	if jqFilter != "" {
 		var jqErr error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a --pretty flag to output human-readable, indented JSON.
* Behavior Changes
  * When --pretty is enabled, JSON is printed with indentation; default output remains compact to preserve existing behavior.
* Refactor
  * Updated internal output handling to improve consistency and enable pretty-printing without affecting other functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->